### PR TITLE
【追加】メッセージウィンドウをマウスクリックで閉じる機能

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -1,6 +1,3 @@
-@import "./common/variables";
-@import "./common/mixin";
-
 .footer {
   width:  $footer_width;
   height: $footer_height;

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -1,6 +1,3 @@
-@import "./common/variables";
-@import "./common/mixin";
-
 $oneLine_bgcolor: $key_color;
 $oneLine_fontcolor: $base_fontcolor;
 

--- a/app/assets/stylesheets/_notification.scss
+++ b/app/assets/stylesheets/_notification.scss
@@ -1,6 +1,3 @@
-@import "./common/variables";
-@import "./common/mixin";
-
 .notice {
   @include notification($hexad_pattern1, $base_fontcolor);
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,8 +10,6 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_self
- *= require_directory
  */
 @import "./initialize/reset";
 @import "./initialize/html_element";
@@ -19,3 +17,11 @@
 @import "font-awesome";
 @import url('https://fonts.googleapis.com/css2?family=M+PLUS+1p:wght@100;400;700;900&display=swap');
 @import url('https://fonts.googleapis.com/earlyaccess/nicomoji.css');
+@import "./common/variables";
+@import "./common/mixin";
+@import "./header";
+@import "./footer";
+@import "./notification";
+@import "./home";
+@import "./registrations";
+

--- a/app/assets/stylesheets/common/_mixin.scss
+++ b/app/assets/stylesheets/common/_mixin.scss
@@ -150,13 +150,14 @@
   background-color: $bgcolor;
   color: $txtcolor;
   z-index: 100;
+  transition: all 600ms 0s ease;
+  opacity: 1;
   &::before {
-    @extend .far;
-    content: fa-content($fa-var-envelope);
+    @extend .fas;
+    content: fa-content($fa-var-check);
     display: inline-block;
-    position: absolute;
-    left: 0;
-    cursor: pointer;
+    margin: 8px;
+    font-size: 120%;
   }
 }
 

--- a/app/assets/stylesheets/common/_mixin.scss
+++ b/app/assets/stylesheets/common/_mixin.scss
@@ -1,4 +1,3 @@
-@import "./variables";
 
 /* Layouts */
 
@@ -146,10 +145,19 @@
   top: 0;
   left: 0;
   width: 100%;
-  padding: 2px;
+  padding: 16px 0;
   text-align: center;
   background-color: $bgcolor;
   color: $txtcolor;
+  z-index: 100;
+  &::before {
+    @extend .far;
+    content: fa-content($fa-var-envelope);
+    display: inline-block;
+    position: absolute;
+    left: 0;
+    cursor: pointer;
+  }
 }
 
 /* Other Styles */

--- a/app/assets/stylesheets/common/_variables.scss
+++ b/app/assets/stylesheets/common/_variables.scss
@@ -1,4 +1,6 @@
+
 /* Sizes */
+
 $browser_max-width: 1200px;
 
 $header_width:  100%;

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,6 +1,3 @@
-@import "./common/variables";
-@import "./common/mixin";
-
 .home {
   @include mainContentLayout($browser_max-width);
 

--- a/app/assets/stylesheets/registrations.scss
+++ b/app/assets/stylesheets/registrations.scss
@@ -1,6 +1,3 @@
-@import "./common/variables";
-@import "./common/mixin";
-
 .userRegistration {
   @include mainContentLayout(600px);
 

--- a/app/javascript/packs/_notification.js
+++ b/app/javascript/packs/_notification.js
@@ -1,0 +1,20 @@
+import Vue from 'vue/dist/vue.js'
+
+const app = new Vue({
+  el: '#vueApp',
+  data: {
+    windowStatus: {
+      visibility: 'visible',
+      opacity: 1
+    }
+  },
+  methods: {
+    closeWindow() {
+      this.windowStatus = {
+        visibility: 'hidden',
+        opacity: 0
+      }
+    }
+  }
+})
+console.log(app)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -7,9 +7,14 @@ html
     = stylesheet_link_tag 'application', media: 'all'
     = javascript_pack_tag 'application'
   body
-    - if notice
-      p.notice = notice
-    - if alert
-      p.alert = alert
-    = render './shared/header'
-    = yield
+    #vueApp
+      - if notice
+        p.notice :style='windowStatus' @click='closeWindow'
+          = notice
+      - if alert
+        p.alert :style='windowStatus' @click='closeWindow'
+          = alert
+      = render './shared/header'
+      = yield
+
+= javascript_pack_tag '_notification'


### PR DESCRIPTION
# What
- Alert および Notice のメッセージウィンドウを、マウスクリックで閉じられるようにした。

# Why
- 表示させっぱなしの場合、ヘッダ部分に重なってUIが悪くなる。